### PR TITLE
Changes widget slug; fixes #3

### DIFF
--- a/wp-home-page-news.php
+++ b/wp-home-page-news.php
@@ -25,7 +25,7 @@ function home_page_news_widget() {
 	if ( current_user_can( 'add_users' ) ) {
 		// Add a pending posts dashboard widget.
 		wp_add_dashboard_widget(
-			'homepage-news_widget',         // Widget slug.
+			'homepage_news_widget',         // Widget slug.
 			'Posts sent to the homepage',   // Title.
 			'homepage_news_widget_function' // Display function.
 		);


### PR DESCRIPTION
This should be immediately able to be merged. The widget slug isn't referenced elsewhere in the code, and doesn't take custom styles from the theme.
